### PR TITLE
feat: Guitar practice app - Random note display with BPM

### DIFF
--- a/docs/sessions/001-guitar-practice.md
+++ b/docs/sessions/001-guitar-practice.md
@@ -1,0 +1,28 @@
+# Session 001: Guitar Practice App
+
+This session implements a guitar practice app that displays random notes (A-G) at a specified BPM.
+
+## Features
+
+- Random note generation from A to G
+- Adjustable BPM (30-240)
+- Visual display of notes
+- React + TypeScript implementation
+- TailwindCSS styling
+
+## Implementation Details
+
+The app consists of two main components:
+
+1. `App.tsx`: Main component that handles BPM state and provides a slider for BPM control
+2. `CodeQuiz.tsx`: Component that displays random notes at the specified BPM
+
+The app uses React's `useState` and `useEffect` hooks to manage state and side effects.
+
+## Future Improvements
+
+- Add support for sharps and flats
+- Add different practice modes (scales, chords, etc.)
+- Add visual metronome
+- Add sound feedback
+- Add practice statistics

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+import { GuitarPractice } from './components/GuitarPractice';
+import { BPMControl } from './components/BPMControl';
+
+function App() {
+  const [bpm, setBpm] = useState(60);
+
+  return (
+    <div className="relative">
+      <div className="fixed top-4 left-1/2 transform -translate-x-1/2 z-10">
+        <BPMControl bpm={bpm} onChange={setBpm} />
+      </div>
+      <GuitarPractice bpm={bpm} />
+    </div>
+  );
+}
+
+export default App;

--- a/src/components/BPMControl.tsx
+++ b/src/components/BPMControl.tsx
@@ -1,0 +1,31 @@
+import { ChangeEvent } from 'react';
+
+interface BPMControlProps {
+  bpm: number;
+  onChange: (bpm: number) => void;
+}
+
+export const BPMControl: React.FC<BPMControlProps> = ({ bpm, onChange }) => {
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = parseInt(e.target.value, 10);
+    onChange(value);
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-2 p-4 bg-white rounded-lg shadow-sm">
+      <label htmlFor="bpm-slider" className="text-lg font-semibold text-gray-700">
+        Tempo (BPM)
+      </label>
+      <input
+        id="bpm-slider"
+        type="range"
+        min="30"
+        max="240"
+        value={bpm}
+        onChange={handleChange}
+        className="w-64 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+      />
+      <div className="text-2xl font-bold text-blue-600">{bpm}</div>
+    </div>
+  );
+};

--- a/src/components/GuitarPractice.tsx
+++ b/src/components/GuitarPractice.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+
+interface GuitarPracticeProps {
+  bpm: number;
+}
+
+const NOTES = ['A', 'B', 'C', 'D', 'E', 'F', 'G'];
+
+export const GuitarPractice: React.FC<GuitarPracticeProps> = ({ bpm }) => {
+  const [currentNote, setCurrentNote] = useState<string>('A');
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  useEffect(() => {
+    if (!isPlaying || bpm <= 0) return;
+
+    const intervalMs = (60 / bpm) * 1000;
+    const interval = setInterval(() => {
+      const randomIndex = Math.floor(Math.random() * NOTES.length);
+      setCurrentNote(NOTES[randomIndex]);
+    }, intervalMs);
+
+    return () => clearInterval(interval);
+  }, [bpm, isPlaying]);
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100">
+      <div className="p-8 bg-white rounded-lg shadow-lg">
+        <div className="text-9xl font-bold mb-8 text-center text-blue-600">
+          {currentNote}
+        </div>
+        <div className="flex gap-4">
+          <button
+            onClick={() => setIsPlaying(!isPlaying)}
+            className={`px-6 py-2 rounded-lg font-semibold ${
+              isPlaying
+                ? 'bg-red-500 hover:bg-red-600 text-white'
+                : 'bg-green-500 hover:bg-green-600 text-white'
+            }`}
+          >
+            {isPlaying ? 'Stop' : 'Start'}
+          </button>
+        </div>
+        <div className="mt-4 text-center text-gray-600">
+          Current BPM: {bpm}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,16 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+  background-color: #f3f4f6;
+}


### PR DESCRIPTION
This PR adds a guitar practice app that displays random notes (A-G) at a specified BPM.

Features:
- Random note generation from A to G
- Adjustable BPM (30-240)
- Visual display of notes
- React + TypeScript implementation
- TailwindCSS styling

See `docs/sessions/001-guitar-practice.md` for more details.